### PR TITLE
fix: include user identity fields in claims

### DIFF
--- a/src/domain/model/BaseClass/User.ts
+++ b/src/domain/model/BaseClass/User.ts
@@ -21,7 +21,15 @@ export class User {
     }
 
     set(params: UserClaimsResponse): this {
-        ({ id: this.id, group_id: this.group_id, permissions: this.permissions, client_id: this.client_id } = params)
+        ({
+            id: this.id,
+            group_id: this.group_id,
+            permissions: this.permissions,
+            client_id: this.client_id,
+            first_name: this.first_name,
+            last_name: this.last_name,
+            email: this.email,
+        } = params)
         return this
     }
 

--- a/src/domain/model/response/UserResponse.ts
+++ b/src/domain/model/response/UserResponse.ts
@@ -33,6 +33,9 @@ export type GetUserDataByIdResult = {
 export type UserClaimsResponse = {
     id: number
     client_id: number
+    first_name: string
+    last_name: string
+    email: string
     group_id: number
     permissions: number[]
 }


### PR DESCRIPTION
## Summary
- ensure `UserClaimsResponse` includes first name, last name, and email
- preserve user identity fields when initializing `User` from JWT claims

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895a476c914833297e6e74c27cf8705