### PR TITLE
feat: implement order creation route with validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "dev": "cross-env NODE_ENV=development nodemon -e ts --exec \"ts-node -r tsconfig-paths/register -r ./src/main.ts\"",
     "migrate:run": "cross-env NODE_ENV=development npx typeorm-ts-node-commonjs migration:run -d src/infrastructure/mysql/connection.ts",
     "migrate:create": "npx typeorm-ts-node-commonjs migration:create",
@@ -57,6 +57,7 @@
     "prettier": "^3.6.2",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "vitest": "^1.3.1"
   }
 }

--- a/src/adapters/inbound/controller/OrderController.ts
+++ b/src/adapters/inbound/controller/OrderController.ts
@@ -9,7 +9,8 @@ export default class OrderController {
         const order = await OrderAppService.CreateOrderApp(
             {
                 ...createOrderParams,
-                status: "OPEN",
+                side: createOrderParams.side?.toUpperCase(),
+                order_type: createOrderParams.order_type?.toUpperCase(),
                 created_at: moment.utc().format("YYYY-MM-DD HH:mm:ss"),
                 updated_at: moment.utc().format("YYYY-MM-DD HH:mm:ss"),
                 client_id: request.user.client_id,

--- a/src/adapters/inbound/http/routes/Order.ts
+++ b/src/adapters/inbound/http/routes/Order.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance, FastifyPluginOptions, RouteOptions } from "fastify"
-// import * as Schema from "@helpers/ApiSchema/ApiSchema"
+import * as Schema from "@helpers/ApiSchema/ApiSchema"
+import { AuthValidate } from "@helpers/prehandler/AuthValidate"
 import OrderController from "@adapters/inbound/controller/OrderController"
 
 const routes: RouteOptions[] = [
@@ -7,28 +8,36 @@ const routes: RouteOptions[] = [
         method: ["POST"],
         url: "/",
         handler: OrderController.CreateOrder,
-        // schema: {
-        //     tags: ["User"],
-        //     response: Schema.BaseResponse({
-        //         type: "Object",
-        //         message: {
-        //             id: { type: "number" },
-        //             symbol: { type: "string" },
-        //             name: { type: "string" },
-        //             asset_type: { type: "string" },
-        //             sector: { type: "string" },
-        //             currency: { type: "string" },
-        //             current_price: { type: "string" },
-        //             price_updated_at: { type: "string" },
-        //             created_at: { type: "string" },
-        //             updated_at: { type: "string" },
-        //         },
-        //     }),
-        // },
+        schema: {
+            tags: ["User"],
+            body: Schema.BaseRequestSchema("Create Order", {
+                portfolio_id: { type: "number", default: "" },
+                asset_id: { type: "number", default: "" },
+                side: { type: "string", default: "" },
+                order_type: { type: "string", default: "" },
+                quantity: { type: "number", default: "" },
+                price: { type: "number", default: "" },
+                stop_loss: { type: "number", default: "" },
+                take_profit: { type: "number", default: "" },
+                order_value: { type: "number", default: "" },
+                notes: { type: "string", default: "" },
+                expires_at: { type: "string", default: "" },
+                broker_order_id: { type: "number", default: "" },
+            }),
+            response: Schema.BaseResponse({
+                type: "Object",
+                message: {
+                    message: { type: "string" },
+                    order_id: { type: "number" },
+                    status: { type: "string" },
+                },
+            }),
+        },
     },
 ]
 
 export default async function OrderRoute(fastify: FastifyInstance, options: FastifyPluginOptions) {
+    fastify.addHook("preValidation", AuthValidate)
     for (const route of routes) {
         fastify.route({ ...route, config: options })
     }

--- a/src/helpers/JoiSchema/Order.ts
+++ b/src/helpers/JoiSchema/Order.ts
@@ -1,7 +1,7 @@
 import Joi from "joi";
 
 export const CreateOrder = Joi.object({
-// portfolio_id, asset_id, side, order_type, quantity, limit_price, status, broker_order_id, filled_quantity, average_fill_price, created_at, updated_at
+// portfolio_id, asset_id, side, order_type, quantity, price, broker_order_id, optional fields
     portfolio_id: Joi.number().min(1).required().messages({
         "number.base": "portfolio_id must be a number",
         "number.min": "portfolio_id must be greater than or equal to 1",
@@ -12,14 +12,14 @@ export const CreateOrder = Joi.object({
         "number.min": "asset_id must be greater than or equal to 1",
         "any.required": "asset_id is required",
     }),
-    side: Joi.string().valid('buy', 'sell').required().messages({
+    side: Joi.string().valid('BUY', 'SELL').required().messages({
         "string.base": "side must be a string",
-        "any.only": "side must be either 'buy' or 'sell'",
+        "any.only": "side must be either 'BUY' or 'SELL'",
         "any.required": "side is required",
     }),
-    order_type: Joi.string().valid('market', 'limit').required().messages({
+    order_type: Joi.string().valid('MARKET', 'LIMIT', 'STOP', 'STOP_LIMIT').required().messages({
         "string.base": "order_type must be a string",
-        "any.only": "order_type must be either 'market' or 'limit'",
+        "any.only": "order_type must be one of 'MARKET', 'LIMIT', 'STOP', or 'STOP_LIMIT'",
         "any.required": "order_type is required",
     }),
     quantity: Joi.number().min(0).required().messages({
@@ -27,15 +27,27 @@ export const CreateOrder = Joi.object({
         "number.min": "quantity must be greater than or equal to 0",
         "any.required": "quantity is required",
     }),
-    limit_price: Joi.number().min(0).required().messages({
-        "number.base": "limit_price must be a number",
-        "number.min": "limit_price must be greater than or equal to 0",
-        "any.required": "limit_price is required",
+    price: Joi.number().min(0).optional().messages({
+        "number.base": "price must be a number",
+        "number.min": "price must be greater than or equal to 0",
     }),
-    status: Joi.string().valid('submitted', 'working', 'filled', 'cancelled', 'rejected').required().messages({
-        "string.base": "status must be a string",
-        "any.only": "status must be one of 'submitted', 'working', 'filled', 'cancelled', or 'rejected'",
-        "any.required": "status is required",
+    stop_loss: Joi.number().min(0).optional().messages({
+        "number.base": "stop_loss must be a number",
+        "number.min": "stop_loss must be greater than or equal to 0",
+    }),
+    take_profit: Joi.number().min(0).optional().messages({
+        "number.base": "take_profit must be a number",
+        "number.min": "take_profit must be greater than or equal to 0",
+    }),
+    order_value: Joi.number().min(0).optional().messages({
+        "number.base": "order_value must be a number",
+        "number.min": "order_value must be greater than or equal to 0",
+    }),
+    notes: Joi.string().allow('').optional().messages({
+        "string.base": "notes must be a string",
+    }),
+    expires_at: Joi.string().allow('').optional().messages({
+        "string.base": "expires_at must be a string",
     }),
     broker_order_id: Joi.number().min(0).required().messages({
         "number.base": "broker_order_id must be a number",

--- a/tests/order.route.test.ts
+++ b/tests/order.route.test.ts
@@ -1,0 +1,52 @@
+import 'tsconfig-paths/register';
+import Fastify from 'fastify';
+import { describe, it, expect, vi } from 'vitest';
+import OrderRoute from '@adapters/inbound/http/routes/Order';
+import OrderAppService from '@application/service/Order';
+
+vi.mock('@helpers/prehandler/AuthValidate', () => ({
+  AuthValidate: vi.fn(async (request: any) => {
+    request.user = { id: 1, client_id: 1, group_id: 1 };
+  })
+}));
+
+vi.mock('@application/service/Order', () => ({
+  default: {
+    CreateOrderApp: vi.fn().mockResolvedValue({
+      message: 'Order submitted successfully for execution.',
+      order_id: 1,
+      status: 'SUBMITTED'
+    })
+  }
+}));
+
+describe('Order Route', () => {
+  it('should create an order successfully', async () => {
+    const app = Fastify();
+    await app.register(OrderRoute, { prefix: '/api/v1/order' });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/order/',
+      headers: { authorization: 'Bearer token' },
+      payload: {
+        portfolio_id: 1,
+        asset_id: 1,
+        side: 'BUY',
+        order_type: 'MARKET',
+        quantity: 10,
+        broker_order_id: 99
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      message: {
+        message: 'Order submitted successfully for execution.',
+        order_id: 1,
+        status: 'SUBMITTED'
+      }
+    });
+    expect(OrderAppService.CreateOrderApp).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- add authentication and validation to order creation route
- normalize order input and schema
- add initial vitest test for create order flow
## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895aa81010c8332bba39b342cf40a0c